### PR TITLE
Use Helm release action that works with tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -146,7 +146,7 @@ jobs:
           version: v3.5.0
 
       - name: Run chart-releaser
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@v1.4.1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -123,7 +123,7 @@ jobs:
           ko publish ./cmd/kubelet-csr-approver/ --base-import-paths --platform=linux/amd64,linux/arm64,linux/arm --tags $TAG
 
   publish-helm-charts:
-    if: "!startsWith(github.ref, 'refs/tags/v') && !github.event.pull_request.head.repo.fork"
+    if: "startsWith(github.ref, 'refs/tags/v') && !github.event.pull_request.head.repo.fork"
     needs:
     - lint
     - test-helm
@@ -146,9 +146,9 @@ jobs:
           version: v3.5.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
 
   publish-untagged:
     if: "!startsWith(github.ref, 'refs/tags/v') && !github.event.pull_request.head.repo.fork"


### PR DESCRIPTION
This is message from Github Action using official Helm chart:

```
Discovering changed charts since 'v0.1.1'...
Nothing to do. No chart changes detected.
```

This is long standing and very annoying issue with Helm's official chart where it doesn't want to do releases on tags.  The only place I have been able to use the Helm official action is repos not using tags to handle releasing a chart.  On several projects I contribute to and many I manage, I've had to use third party actions to handle releases to gh-pages for Helm charts.