### PR TITLE
Feat/expiration sec

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -101,6 +101,7 @@ jobs:
             -e 's|repository:.*|repository: ko.local/kubelet-csr-approver|g' \
             -e 's|tag:.*|tag: latest|g' \
             -e 's|providerRegex:.*|providerRegex: ^.+$|g' \
+            -e 's|maxExpirationSeconds:.*|maxExpirationSeconds: 86400|g' \
             charts/kubelet-csr-approver/values.yaml
           cat charts/kubelet-csr-approver/values.yaml
       - name: Run chart-testing (install)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -101,7 +101,7 @@ jobs:
             -e 's|repository:.*|repository: ko.local/kubelet-csr-approver|g' \
             -e 's|tag:.*|tag: latest|g' \
             -e 's|providerRegex:.*|providerRegex: ^.+$|g' \
-            -e 's|maxExpirationSeconds:.*|maxExpirationSeconds: 86400|g' \
+            -e 's|maxExpirationSeconds:.*|maxExpirationSeconds: "86400"|g' \
             charts/kubelet-csr-approver/values.yaml
           cat charts/kubelet-csr-approver/values.yaml
       - name: Run chart-testing (install)

--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ Certificates.
    `kubelet-csr-approver` will approve (or deny) depending on the deployment
    parameters you have set.
 
-The most important parameter that needs to be changed is the `PROVIDER_REGEX`
-environment variable: it lets you decide which hostnames can be approved or
-not. i.e., if all your nodes follow a naming convention (such as
-`node-randomstr1234.int.company.ch`), your regex could look like
-`^node-\w*\.int\.company\.ch$`
+### parameters
 
-It is also important to understand that the node DNS name needs to be
+The most important parameters (configurable through environment variables) that
+need to be changed are:
+
+* `PROVIDER_REGEX` lets you decide which hostnames can be approved or not\
+  e.g. if all your nodes follow a naming convention (say
+  `node-randomstr1234.int.company.ch`), your regex could look like
+  `^node-\w*\.int\.company\.ch$`
+* `MAX_EXPIRATION_SEC` permits to specify the maximum `expirationSeconds`
+  the kubelet can ask for.\
+  Per default it is hardcoded to a maximum of 368 days, and changing this environment
+  permits to reduce this value
+
+It is important to understand that the node DNS name needs to be
 resolvable for the `kubelet-csr-approver` to work properly. If this is an issue
 for you, please file an issue and I'll add a flag to disable this validation.
 
@@ -73,22 +81,24 @@ Taking inspiration from [Kubernetes built-in CSR
 approver](https://github.com/kubernetes/kubernetes/blob/v1.22.2/pkg/controller/certificates/approver/sarapprove.go),
 we check the following criteria:
 
-- the `CSR.Spec.SignerName` name must be `"kubernetes.io/kubelet-serving"`
-- the `CSR.Spec.Username` must be prefixed with `system:node:` (i.e. we only
+* `CSR.Spec.SignerName` must be `"kubernetes.io/kubelet-serving"`
+* `CSR.Spec.ExpirationSeconds`, if specified, must be smaller than `MAX_EXPIRATION_SEC`\
+  (the default value and hard-coded maximum for this controller is 368 days)
+* `CSR.Spec.Username` must be prefixed with `system:node:` (i.e. we only
   want to treat CSRs originating from the nodes themselves)
-- the CSR `CommonName` must be equal to the `CSR.Spec.Username`
-- the CSR DNS SubjectAlternativeNames (SAN) contains at most one entry
-- at least one SAN IP address or SAN DNS Name must be specified
-- the CSR SAN DNS Name (if specified) must comply with a provider-specific
+* x509 CR `CommonName` must be equal to the `CSR.Spec.Username`
+* CSR DNS SubjectAlternativeNames (SAN) contains at most one entry
+* at least one SAN IP address or SAN DNS Name must be specified
+* CSR SAN DNS Name (if specified) must comply with a provider-specific
   regex.
-- the CSR SAN DNS Name (if specified) must be prefixed with the node hostname
+* CSR SAN DNS Name (if specified) must be prefixed with the node hostname
   (where the hostname corresponds to `CSR.Spec.Username` trimmed of the
   `system:node:` prefix)
-- the CSR SAN IP Addresses must all be part of the set of IP addresses resolved
+* CSR SAN IP Addresses must all be part of the set of IP addresses resolved
   from the SAN DNS Name
-- ⚠ the CSR SAN DNS Name (if specified) must resolve to IP address(es) that
+* ⚠ the CSR SAN DNS Name (if specified) must resolve to IP address(es) that
   fall within the set of provider-specified IP ranges.
-- ⚠ the CSR SAN IP Address(es) must fall within a set of provider-specified IP
+* ⚠ the CSR SAN IP Address(es) must fall within a set of provider-specified IP
   ranges
 
 ⚠ == not yet implemented
@@ -96,14 +106,14 @@ we check the following criteria:
 With those verifications in place, it makes it quite hard for an attacker to
 get a forged hostname to be signed, it would indeed require:
 
-- to impersonate a user on the Kubernetes API server with a `Username` that
+* to impersonate a user on the Kubernetes API server with a `Username` that
   prefixes the SAN DNS Name request. \ concretely, if the attacker wants to
   forge a CSR for the `auth.company.ch` domain, s/he would need to create a CSR
   with the username `system:node:a` (remember, we only check the that the DNS
   name is prefixed by the node name) \ it might then be possible to create a
   CSR from a node `a` (not a smart name for a node, I agree), or a node `auth`,
   already more plausible
-- to modify the provider-specific regex of the `kubelet-csr-approver` (requires
+* to modify the provider-specific regex of the `kubelet-csr-approver` (requires
   API access or direct access to the node where the controller is running). \
   however with API access, the attacker could as well also directly approve the
   CSR, and with full node access, the attacker could retrieve the controller's

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ need to be changed are:
   `^node-\w*\.int\.company\.ch$`
 * `MAX_EXPIRATION_SEC` permits to specify the maximum `expirationSeconds`
   the kubelet can ask for.\
-  Per default it is hardcoded to a maximum of 368 days, and changing this environment
+  Per default it is hardcoded to a maximum of 367 days, and changing this environment
   permits to reduce this value
 
 It is important to understand that the node DNS name needs to be
@@ -47,12 +47,13 @@ mechanisms are put in place.
 
 ## Helm Install
 
-Adjust `providerRegex` as needed.
+Adjust `providerRegex` and `maxExpirationSeconds` as needed.
 
 ```bash
 helm repo add kubelet-csr-approver https://postfinance.github.io/kubelet-csr-approver
 helm install kubelet-csr-approver kubelet-csr-approver/kubelet-csr-approver -n kube-system \
-  --set providerRegex='^node-\w*\.int\.company\.ch$'
+  --set providerRegex='^node-\w*\.int\.company\.ch$' \
+  --set maxExpirationSeconds='86400'
 ```
 
 ## attacker model -- what could go wrong ?
@@ -83,7 +84,7 @@ we check the following criteria:
 
 * `CSR.Spec.SignerName` must be `"kubernetes.io/kubelet-serving"`
 * `CSR.Spec.ExpirationSeconds`, if specified, must be smaller than `MAX_EXPIRATION_SEC`\
-  (the default value and hard-coded maximum for this controller is 368 days)
+  (the default value and hard-coded maximum for this controller is 367 days)
 * `CSR.Spec.Username` must be prefixed with `system:node:` (i.e. we only
   want to treat CSRs originating from the nodes themselves)
 * x509 CR `CommonName` must be equal to the `CSR.Spec.Username`

--- a/charts/kubelet-csr-approver/Chart.yaml
+++ b/charts/kubelet-csr-approver/Chart.yaml
@@ -7,4 +7,3 @@ appVersion: v0.1.1
 maintainers:
   - name: clementnuss
   - name: treydock
-

--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
             - name: PROVIDER_REGEX
               value: {{ .Values.providerRegex }}
           {{- end }}
+          {{- if .Values.maxExpirationSeconds}}
+          env:
+            - name: MAX_EXPIRATION_SECONDS
+              value: {{ .Values.maxExpirationSeconds }}
+          {{- end }}
           {{- if .Values.metrics.enable }}
           ports:
             - name: metrics

--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -36,13 +36,12 @@ spec:
             - ":{{ .Values.metrics.port }}"
             - -health-probe-bind-address
             - ":8081"
-          {{- if .Values.providerRegex }}
           env:
+          {{- if .Values.providerRegex }}
             - name: PROVIDER_REGEX
               value: {{ .Values.providerRegex }}
           {{- end }}
           {{- if .Values.maxExpirationSeconds}}
-          env:
             - name: MAX_EXPIRATION_SECONDS
               value: {{ .Values.maxExpirationSeconds | quote }}
           {{- end }}

--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           {{- if .Values.maxExpirationSeconds}}
           env:
             - name: MAX_EXPIRATION_SECONDS
-              value: {{ .Values.maxExpirationSeconds }}
+              value: {{ .Values.maxExpirationSeconds | quote }}
           {{- end }}
           {{- if .Values.metrics.enable }}
           ports:

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -1,6 +1,6 @@
 # Required configuration item
 providerRegex: ""
-#optional, specified as a string (enclosed with ""). if left empty, defaults to 367 days
+# optional, specified as a string (enclosed with ""). if left empty, defaults to 367 days
 maxExpirationSeconds: ""
 
 namespace: ""

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -1,7 +1,9 @@
 # Required configuration item
 providerRegex: ""
+#optional, specified as a string (enclosed with ""). if left empty, defaults to 367 days
+maxExpirationSeconds: ""
 
-namespace: ''
+namespace: ""
 
 image:
   repository: postfinance/kubelet-csr-approver

--- a/cmd/kubelet-csr-approver/main.go
+++ b/cmd/kubelet-csr-approver/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.IntVar(&logLevel, "level", 0, "level ranges from -5 (Fatal) to 10 (MAX_EXPIRATION_SEC)")
+	flag.IntVar(&logLevel, "level", 0, "level ranges from -5 (Fatal) to 10 (Verbose)")
 	flag.Parse()
 
 	if logLevel < -5 || logLevel > 10 {

--- a/controller/csr_controller_test.go
+++ b/controller/csr_controller_test.go
@@ -137,3 +137,22 @@ func TestMismatchedResolvedIpsSANIps(t *testing.T) {
 	assert.False(t, approved)
 
 }
+
+func TestExpirationSecondsTooLarge(t *testing.T) {
+	csrParams := CsrParams{
+		csrName:           "expiration-seconds",
+		expirationSeconds: 368 * 24 * 3600,
+		nodeName:          testNodeName,
+	}
+	csr := createCsr(t, csrParams)
+	_, nodeClientSet, _ := createControlPlaneUser(t, csr.Spec.Username, []string{"system:masters"})
+
+	_, err := nodeClientSet.CertificatesV1().CertificateSigningRequests().Create(testContext, &csr, metav1.CreateOptions{})
+	require.Nil(t, err, "Could not create the CSR.")
+
+	approved, denied, err := waitCsrApprovalStatus(csr.Name)
+	require.Nil(t, err, "Could not retrieve the CSR to check its approval status")
+	assert.True(t, denied)
+	assert.False(t, approved)
+
+}

--- a/controller/csr_controller_test.go
+++ b/controller/csr_controller_test.go
@@ -141,7 +141,7 @@ func TestMismatchedResolvedIpsSANIps(t *testing.T) {
 func TestExpirationSecondsTooLarge(t *testing.T) {
 	csrParams := CsrParams{
 		csrName:           "expiration-seconds",
-		expirationSeconds: 368 * 24 * 3600,
+		expirationSeconds: 368 * 24 * 3600, // one day more than the maximum of 367
 		nodeName:          testNodeName,
 	}
 	csr := createCsr(t, csrParams)


### PR DESCRIPTION
add maximum expirationSeconds field check, to prevent CSR longer than a year (or less, -configurable) to be approved.

- [x] create tests for the feature
- [x] document
- [x] modify helm chart and document