### PR TITLE
add IP whitelisting capability

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -233,8 +233,8 @@ jobs:
         env:
           KO_DOCKER_REPO: docker.io/postfinance
       - name: Run ko publish
-        # TODO: make the tag correspond to the branch name
         run: |
           export REF=${{ github.ref}}
           export COMMIT=${{ github.sha}}
-          ko publish ./cmd/kubelet-csr-approver/ --base-import-paths --platform=linux/amd64,linux/arm64,linux/arm -t feat
+          export FEAT=$(echo $REF  | awk -F 'feat/' '{print $2}')
+          ko publish ./cmd/kubelet-csr-approver/ --base-import-paths --platform=linux/amd64,linux/arm64,linux/arm -t $FEAT

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -179,6 +179,7 @@ jobs:
     - check-gh-token
     if: |
       !startsWith(github.ref, 'refs/tags/v') &&
+      github.ref == 'refs/heads/dev' &&
       !github.event.pull_request.head.repo.fork &&
       needs.check-gh-token.outputs.gh-token == 'true'
     runs-on: ubuntu-latest
@@ -203,3 +204,37 @@ jobs:
           export REF=${{ github.ref}}
           export COMMIT=${{ github.sha}}
           ko publish ./cmd/kubelet-csr-approver/ --base-import-paths --platform=linux/amd64,linux/arm64,linux/arm
+
+  publish-feature:
+    needs:
+    - lint
+    - test
+    - check-gh-token
+    if: |
+      startsWith(github.ref, 'refs/heads/feat') &&
+      !startsWith(github.ref, 'refs/tags/v') &&
+      !github.event.pull_request.head.repo.fork &&
+      needs.check-gh-token.outputs.gh-token == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+          stable: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: postfinance
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: imjasonh/setup-ko@v0.4
+        name: Setup ko
+        env:
+          KO_DOCKER_REPO: docker.io/postfinance
+      - name: Run ko publish
+        # TODO: make the tag correspond to the branch name
+        run: |
+          export REF=${{ github.ref}}
+          export COMMIT=${{ github.sha}}
+          ko publish ./cmd/kubelet-csr-approver/ --base-import-paths --platform=linux/amd64,linux/arm64,linux/arm -t feat

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ variables) are:
 * `--provider-ip-prefixes`  or `PROVIDER_IP_PREFIXES` permits to specify a
   comma-separated list of IP (v4 or/and v6) subnets/prefixes, that CSR IP
   addresses shall fall into. left unspecified, all IP addresses are allowed. \
-  you can for example set it to `192.168.0.0/16,fc00/7` if this reflects your
+  you can for example set it to `192.168.0.0/16,fc00::/7` if this reflects your
   local network IP ranges.
 
 It is important to understand that the node DNS name needs to be

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ variables) are:
   setting it to `true` (or any other option listed in GoLang's
   [`ParseBool`](https://github.com/golang/go/blob/master/src/strconv/atob.go#L10)
   function)
+* `--provider-ip-prefixes`  or `PROVIDER_IP_PREFIXES` permits to specify a
+  comma-separated list of IP (v4 or/and v6) subnets/prefixes, that CSR IP
+  addresses shall fall into. left unspecified, all IP addresses are allowed. \
+  you can for example set it to `192.168.0.0/16,fc00/7` if this reflects your
+  local network IP ranges.
 
 It is important to understand that the node DNS name needs to be
 resolvable for the `kubelet-csr-approver` to work properly. If this is an issue
@@ -106,7 +111,7 @@ we check the following criteria:
   from the SAN DNS Name
 * ⚠ the CSR SAN DNS Name (if specified) must resolve to IP address(es) that
   fall within the set of provider-specified IP ranges.
-* ⚠ the CSR SAN IP Address(es) must fall within a set of provider-specified IP
+* the CSR SAN IP Address(es) must fall within a set of provider-specified IP
   ranges
 
 ⚠ == not yet implemented

--- a/README.md
+++ b/README.md
@@ -109,12 +109,10 @@ we check the following criteria:
   `system:node:` prefix)
 * CSR SAN IP Addresses must all be part of the set of IP addresses resolved
   from the SAN DNS Name
-* ⚠ the CSR SAN DNS Name (if specified) must resolve to IP address(es) that
+* the CSR SAN DNS Name (if specified) must resolve to IP address(es) that
   fall within the set of provider-specified IP ranges.
 * the CSR SAN IP Address(es) must fall within a set of provider-specified IP
   ranges
-
-⚠ == not yet implemented
 
 With those verifications in place, it makes it quite hard for an attacker to
 get a forged hostname to be signed, it would indeed require:

--- a/internal/controller/csr_controller.go
+++ b/internal/controller/csr_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"inet.af/netaddr"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +46,7 @@ type CertificateSigningRequestReconciler struct {
 	client.Client
 	Scheme               *runtime.Scheme
 	ProviderRegexp       func(string) bool
+	ProviderIPSet        *netaddr.IPSet
 	MaxExpirationSeconds int32
 	BypassDNSResolution  bool
 	Resolver             HostResolver
@@ -55,7 +57,8 @@ type CertificateSigningRequestReconciler struct {
 //+kubebuilder:rbac:groups=certificates.k8s.io,resources=signers,resourceNames="kubernetes.io/kubelet-serving",verbs=approve
 
 // Reconcile will perform a series of checks before deciding whether the CSR should be approved or denied
-//nolint: gocyclo // cyclomatic complexity is high (over 15), but this improves readibility for the programmer, therefore we ignore the linting error
+// readibility for the programmer, therefore we ignore the linting error
+//nolint: gocyclo // cyclomatic complexity is high (over 15), but this improves
 func (r *CertificateSigningRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, returnErr error) {
 	l := log.FromContext(ctx)
 

--- a/internal/controller/csr_controller.go
+++ b/internal/controller/csr_controller.go
@@ -127,6 +127,7 @@ func (r *CertificateSigningRequestReconciler) Reconcile(ctx context.Context, req
 			return res, err // returning a non-nil error to make this request be processed again in the reconcile function
 		}
 		l.V(0).Info("Denying kubelet-serving CSR. IP whitelist check failed. Reason:" + reason)
+		appendCondition(&csr, false, reason)
 	} else if csr.Spec.ExpirationSeconds != nil && *csr.Spec.ExpirationSeconds > r.MaxExpirationSeconds {
 		reason := "CSR spec.expirationSeconds is longer than the maximum allowed expiration second"
 		l.V(0).Info("Denying kubelet-serving CSR. Reason:" + reason)

--- a/internal/controller/csr_controller_test.go
+++ b/internal/controller/csr_controller_test.go
@@ -64,10 +64,10 @@ func TestWrongSignerCsr(t *testing.T) {
 
 func TestNonMatchingCommonNameUsername(t *testing.T) {
 	csrParams := CsrParams{
-		csrName:    "csr-non-matching",
-		commonName: "funny-common-name",
-
-		ipAddresses: testNodeIpAddresses, nodeName: testNodeName}
+		csrName:     "csr-non-matching",
+		commonName:  "funny-common-name",
+		ipAddresses: testNodeIpAddresses,
+		nodeName:    testNodeName}
 	csr := createCsr(t, csrParams)
 	_, nodeClientSet, _ := createControlPlaneUser(t, csr.Spec.Username, []string{"system:masters"})
 

--- a/internal/controller/regex_ip_checks.go
+++ b/internal/controller/regex_ip_checks.go
@@ -103,5 +103,5 @@ func (r *CertificateSigningRequestReconciler) WhitelistedIPCheck(csr *certificat
 		}
 	}
 
-	return valid, reason, nil
+	return true, reason, nil
 }

--- a/internal/controller/testenv_setup_test.go
+++ b/internal/controller/testenv_setup_test.go
@@ -82,7 +82,6 @@ type CsrParams struct {
 
 var (
 	testNodeName        string
-	testNodeIps         []string
 	testNodeIpAddresses []net.IP
 )
 
@@ -168,15 +167,20 @@ func packageSetup() {
 	}
 	adminClientset = clientset.NewForConfigOrDie(cfg)
 
-	testNodeIps := []string{"192.168.14.34"}
-	for _, ip := range testNodeIps {
+	testNodeIpv4 := []string{"192.168.14.34"}
+	testNodeIpv6 := []string{"fc00:1291:feed::cafe"}
+	for _, ip := range testNodeIpv4 {
+		testNodeIpAddresses = append(testNodeIpAddresses, net.ParseIP(ip))
+	}
+	for _, ip := range testNodeIpv6 {
 		testNodeIpAddresses = append(testNodeIpAddresses, net.ParseIP(ip))
 	}
 	testNodeName = randstr.String(4, "0123456789abcdefghijklmnopqrstuvwxyz")
 	dnsResolver = mockdns.Resolver{
 		Zones: map[string]mockdns.Zone{
 			testNodeName + ".test.ch.": {
-				A: testNodeIps,
+				A:    testNodeIpv4,
+				AAAA: testNodeIpv6,
 			},
 		},
 	}

--- a/internal/controller/testenv_setup_test.go
+++ b/internal/controller/testenv_setup_test.go
@@ -182,10 +182,11 @@ func packageSetup() {
 	}
 
 	testingConfig := cmd.Config{
-		RegexStr:    `^[\w-]*\.test\.ch$`,
-		MaxSec:      367 * 24 * 3600,
-		K8sConfig:   cfg,
-		DNSResolver: &dnsResolver,
+		RegexStr:      `^[\w-]*\.test\.ch$`,
+		MaxSec:        367 * 24 * 3600,
+		K8sConfig:     cfg,
+		DNSResolver:   &dnsResolver,
+		IPPrefixesStr: "192.168.0.0/16",
 	}
 
 	csrCtrl, mgr, errorCode := cmd.CreateControllerManager(&testingConfig)

--- a/internal/controller/testenv_setup_test.go
+++ b/internal/controller/testenv_setup_test.go
@@ -98,10 +98,6 @@ func createCsr(t *testing.T, params CsrParams) certificates_v1.CertificateSignin
 		params.nodeName = randstr.String(4, "0123456789abcdefghijklmnopqrstuvwxyz")
 	}
 
-	if len(params.dnsName) == 0 {
-		params.dnsName = params.nodeName + ".test.ch"
-	}
-
 	csr.Spec.SignerName = certificates_v1.KubeletServingSignerName
 	csr.Spec.Usages = append(csr.Spec.Usages,
 		certificates_v1.UsageDigitalSignature,
@@ -124,9 +120,12 @@ func createCsr(t *testing.T, params CsrParams) certificates_v1.CertificateSignin
 			Organization: []string{"system:nodes"},
 			CommonName:   params.commonName,
 		},
-		DNSNames:    []string{params.dnsName},
 		IPAddresses: params.ipAddresses,
 	}
+	if len(params.dnsName) > 0 {
+		x509RequestTemplate.DNSNames = []string{params.dnsName}
+	}
+
 	x509Request, _ := x509.CreateCertificateRequest(rand.Reader, &x509RequestTemplate, priv)
 	pemRequest := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE REQUEST",

--- a/internal/controller/testenv_setup_test.go
+++ b/internal/controller/testenv_setup_test.go
@@ -186,7 +186,7 @@ func packageSetup() {
 		MaxSec:        367 * 24 * 3600,
 		K8sConfig:     cfg,
 		DNSResolver:   &dnsResolver,
-		IPPrefixesStr: "192.168.0.0/16",
+		IPPrefixesStr: "192.168.0.0/16,fc00::/7",
 	}
 
 	csrCtrl, mgr, errorCode := cmd.CreateControllerManager(&testingConfig)


### PR DESCRIPTION
as documented in the Readme, it is now possible to specify `--provider-ip-prefixes` such as `192.168.0.0/16,fc00::/7`, thereby permitting that CSR only require IP addresses for well-known subnets