### PR TITLE
Add support for dnsPolicy to the Helm chart

### DIFF
--- a/charts/kubelet-csr-approver/Chart.yaml
+++ b/charts/kubelet-csr-approver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubelet-csr-approver
 description: Kubelet CSR Approver
 type: application
-version: v0.2.0
-appVersion: v0.2.0
+version: v0.2.1
+appVersion: v0.2.1
 maintainers:
   - name: clementnuss
   - name: treydock

--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         {{- include "kubelet-csr-approver.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -77,3 +77,5 @@ rbac:
 env: []
 #   - name: FOO
 #     value: bar
+
+dnsPolicy: ""


### PR DESCRIPTION
Running the csr-approver with dnsPolicy: Default should works fine and removes the dependency to CoreDNS. It's a nice catch on initial cluster bootstrapping.

I also bump the helm chart version in prepare for a next release. Please note, that the `v` prefix of a helm chart version is not officially supported, since it requires to be a SemVer value.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/1560587/161965975-16c44092-435f-4470-a77c-cf46d4223f83.png">
