### PR TITLE
feat: support deploy in out-of-cluster mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -56,7 +56,9 @@ func CreateControllerManager(config *controller.Config, logger logr.Logger) (
 ) {
 	logger.V(0).Info("Kubelet-CSR-Approver controller starting.", "commit", commit, "ref", ref)
 
-	config.K8sConfig = ctrl.GetConfigOrDie()
+	if config.K8sConfig == nil { // when testing, this variable is already set
+		config.K8sConfig = ctrl.GetConfigOrDie()
+	}
 
 	if config.RegexStr == "" {
 		logger.V(-5).Info("the provider-spefic regex must be specified, exiting")

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"github.com/postfinance/kubelet-csr-approver/internal/controller"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"github.com/go-logr/logr"
 )
 
 //nolint:gochecknoglobals //this vars are set on build by goreleaser
@@ -31,7 +33,8 @@ var (
 // Run will start the controller with the default settings
 func Run() int {
 	config := prepareCmdlineConfig()
-	_, mgr, errorCode := CreateControllerManager(config)
+	logger := controller.InitLogger(config)
+	_, mgr, errorCode := CreateControllerManager(config, logger)
 
 	if errorCode != 0 {
 		return errorCode
@@ -49,33 +52,22 @@ func Run() int {
 }
 
 // CreateControllerManager permits creation/customization of the controller-manager
-func CreateControllerManager(config *controller.Config) (
+func CreateControllerManager(config *controller.Config, logger logr.Logger) (
 	csrController *controller.CertificateSigningRequestReconciler,
 	mgr ctrl.Manager,
 	code int,
 ) {
-	// logger initialization
-	flashLogger := flash.New()
-	if config.LogLevel < -5 || config.LogLevel > 10 {
-		flashLogger.Fatal(fmt.Errorf("log level should be between -5 and 10 (included)"))
-	}
+	logger.V(0).Info("Kubelet-CSR-Approver controller starting.", "commit", commit, "ref", ref)
 
+	config.K8sConfig = ctrl.GetConfigOrDie()
+
+	if config.RegexStr == "" {
+		logger.V(-5).Info("the provider-spefic regex must be specified, exiting")
+		return nil, nil, 10
+	}
 	csrController = &controller.CertificateSigningRequestReconciler{
 		Config: *config,
 	}
-
-	config.LogLevel *= -1 // we inverse the level for the logging behavior between zap and logr.Logger to match
-	flashLogger.SetLevel(zapcore.Level(config.LogLevel))
-	z := zapr.NewLogger(flashLogger.Desugar())
-
-	z.V(0).Info("Kubelet-CSR-Approver controller starting.", "commit", commit, "ref", ref)
-
-	if config.RegexStr == "" {
-		z.V(-5).Info("the provider-spefic regex must be specified, exiting")
-
-		return nil, nil, 10
-	}
-
 	csrController.ProviderRegexp = regexp.MustCompile(config.RegexStr).MatchString
 
 	// IP Prefixes parsing and IPSet construction
@@ -84,7 +76,7 @@ func CreateControllerManager(config *controller.Config) (
 	for _, ipPrefix := range strings.Split(config.IPPrefixesStr, ",") {
 		ipPref, err := netaddr.ParseIPPrefix(ipPrefix)
 		if err != nil {
-			z.V(-5).Info(fmt.Sprintf("Unable to parse IP prefix: %s, exiting", ipPrefix))
+			logger.V(-5).Info(fmt.Sprintf("Unable to parse IP prefix: %s, exiting", ipPrefix))
 
 			return nil, nil, 10
 		}
@@ -96,19 +88,19 @@ func CreateControllerManager(config *controller.Config) (
 	csrController.ProviderIPSet, err = setBuilder.IPSet()
 
 	if err != nil {
-		z.V(-5).Info("Unable to build the Set of valid IP addresses, exiting")
+		logger.V(-5).Info("Unable to build the Set of valid IP addresses, exiting")
 
 		return nil, nil, 10
 	}
 
-	ctrl.SetLogger(z)
+	ctrl.SetLogger(logger)
 	mgr, err = ctrl.NewManager(config.K8sConfig, ctrl.Options{
 		MetricsBindAddress:     config.MetricsAddr,
 		HealthProbeBindAddress: config.ProbeAddr,
 	})
 
 	if err != nil {
-		z.Error(err, "unable to start manager")
+		logger.Error(err, "unable to start manager")
 
 		return nil, nil, 10
 	}
@@ -118,13 +110,13 @@ func CreateControllerManager(config *controller.Config) (
 	csrController.Scheme = mgr.GetScheme()
 
 	if err = csrController.SetupWithManager(mgr); err != nil {
-		z.Error(err, "unable to create controller", "controller", "CertificateSigningRequest")
+		logger.Error(err, "unable to create controller", "controller", "CertificateSigningRequest")
 
 		return nil, nil, 10
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		z.Error(err, "unable to set up health check")
+		logger.Error(err, "unable to set up health check")
 
 		return nil, nil, 10
 	}
@@ -132,9 +124,24 @@ func CreateControllerManager(config *controller.Config) (
 	return csrController, mgr, 0
 }
 
+//
+func initLogger(config *controller.Config) logr.Logger {
+	// logger initialization
+	flashLogger := flash.New()
+	if config.LogLevel < -5 || config.LogLevel > 10 {
+		flashLogger.Fatal(fmt.Errorf("log level should be between -5 and 10 (included)"))
+	}
+	config.LogLevel *= -1 // we inverse the level for the logging behavior between zap and logr.Logger to match
+	flashLogger.SetLevel(zapcore.Level(config.LogLevel))
+	logger := zapr.NewLogger(flashLogger.Desugar())
+	ctrl.SetLogger(logger)
+
+	return logger
+}
+
 func prepareCmdlineConfig() *controller.Config {
 	fs := flag.NewFlagSet("kubelet-csr-approver", flag.ExitOnError)
-
+	ctrlconfig.RegisterFlags(fs)
 	var (
 		logLevel               = fs.Int("level", 0, "level ranges from -5 (Fatal) to 10 (Verbose)")
 		metricsAddr            = fs.String("metrics-bind-address", ":8080", "address the metric endpoint binds to.")
@@ -183,7 +190,6 @@ func prepareCmdlineConfig() *controller.Config {
 	}
 
 	config.DNSResolver = net.DefaultResolver
-	config.K8sConfig = ctrl.GetConfigOrDie()
 
 	return &config
 }

--- a/internal/controller/testenv_setup_test.go
+++ b/internal/controller/testenv_setup_test.go
@@ -212,7 +212,7 @@ func packageSetup() {
 		IPPrefixesStr:          "192.168.0.0/16,fc00::/7",
 	}
 
-	csrCtrl, mgr, errorCode := cmd.CreateControllerManager(&testingConfig)
+	csrCtrl, mgr, errorCode := cmd.CreateControllerManager(&testingConfig, controller.InitLogger(&testingConfig))
 	csrController = csrCtrl
 	if errorCode != 0 {
 		log.Fatalf("unable to create controller-runtime manager. Error:\n%v", errorCode)

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -21,12 +21,13 @@ import (
 	"encoding/pem"
 	"errors"
 
-	capiv1 "k8s.io/api/certificates/v1"
-	"github.com/go-logr/logr"
-	"github.com/postfinance/flash"
 	"fmt"
-	"go.uber.org/zap/zapcore"
+
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
+	"github.com/postfinance/flash"
+	"go.uber.org/zap/zapcore"
+	capiv1 "k8s.io/api/certificates/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -65,12 +66,14 @@ func ParseCSR(pemBytes []byte) (*x509.CertificateRequest, error) {
 	return csr, nil
 }
 
+// InitLogger logger initialization
 func InitLogger(config *Config) logr.Logger {
 	// logger initialization
 	flashLogger := flash.New()
 	if config.LogLevel < -5 || config.LogLevel > 10 {
 		flashLogger.Fatal(fmt.Errorf("log level should be between -5 and 10 (included)"))
 	}
+
 	config.LogLevel *= -1 // we inverse the level for the logging behavior between zap and logr.Logger to match
 	flashLogger.SetLevel(zapcore.Level(config.LogLevel))
 	logger := zapr.NewLogger(flashLogger.Desugar())


### PR DESCRIPTION
This PR has 2 features:

1. I use `kubelet-csr-approver` for automatic approve node serving certificates. I need it can be deployed in a K8s cluster in an out-of-cluster mode. Therefore, I hope it can support the `-kubeconfig` flag to specify the kubeconfig file outside the cluster.

2. When I specify kubeconfig flag, if the file does not exist, the program exits without any error message, which is obviously abnormal. The reason is that the `logger` is not initialized when the logic of `ctrl.GetConfigOrDie()` is executed, so I refactored part of the code logic in `internal/cmd/cmd.go`.

Now, it works fine for me with little code changes, and I look forward to receiving some suggestions for modifying this PR, thanks~