### PR TITLE
chore: omit deprecated node-role.kubernetes.io/master taint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Inspired by existing projects (such as
 implements additional verifications to prevent an attacker from forging
 Certificates.
 
+Kubelet CSR approver is being kept up-to-date in accordance with the [most recent three Kubernetes minor releases](https://kubernetes.io/releases/).
+
 ## Quick start
 
 1. deploy `kubelet-csr-approver` on your k8s cluster using the manifests

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -71,9 +71,6 @@ nodeSelector: {}
 
 tolerations:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
     operator: Equal
 

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -47,8 +47,5 @@ spec:
 
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Equal
-        - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Equal


### PR DESCRIPTION
Fixes https://github.com/postfinance/kubelet-csr-approver/issues/123

This PR is marked as draft as it shall not be merged until Kubernetes 1.27 is released.
This way users do not have to worry about compatibility between this project and their Kubernetes version as the latest 3 minor releases will be supported.

Will merge this PR in April 2023 (see [Kubernetes 1.27 release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.27))