### PR TITLE
feat: Add flag for prometheus-operator SMon

### DIFF
--- a/charts/kubelet-csr-approver/templates/servicemonitor.yaml
+++ b/charts/kubelet-csr-approver/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.metrics.enable .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kubelet-csr-approver.fullname" . }}
+  namespace: {{ include "kubelet-csr-approver.namespace" . }}
+  labels:
+    {{- include "kubelet-csr-approver.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- with .Values.metrics.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    {{- include "kubelet-csr-approver.selectorLabels" . | nindent 4 }}
+  endpoints:
+    - port: {{ .Values.metrics.port }}
+      path: /metrics
+      scheme: http
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout  }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -38,6 +38,13 @@ metrics:
   serviceType: ClusterIP
   port: 8080
   annotations: {}
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    interval: 1m
+    scrapeTimeout: 10s
+    metricRelabelings: []
+    relabelings: []
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This adds a flag to the helm chart to deploy a ServiceMonitor compatible with the prometheus-operator CRDs.