### PR TITLE
add missing rbac to clusterrole

### DIFF
--- a/charts/kubelet-csr-approver/templates/clusterrole.yaml
+++ b/charts/kubelet-csr-approver/templates/clusterrole.yaml
@@ -14,6 +14,12 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 {{- end }}
 - apiGroups:
   - certificates.k8s.io

--- a/deploy/k8s/clusterrole.yaml
+++ b/deploy/k8s/clusterrole.yaml
@@ -34,3 +34,9 @@ rules:
   - signers
   verbs:
   - approve
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create


### PR DESCRIPTION
After deployment via helmchart we saw the following error message:
```
...
(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:kubelet-csr-approver:kubelet-csr-approver" cannot create resource "events" in API group "" in the namespace "kubelet-csr-approver"' (will not retry!)
```
This PR adds the missing rbac rule to create the events from the LeaderElection