### PR TITLE
fix: invalid syntax in ServiceMonitor helm template

### DIFF
--- a/charts/kubelet-csr-approver/templates/servicemonitor.yaml
+++ b/charts/kubelet-csr-approver/templates/servicemonitor.yaml
@@ -9,8 +9,8 @@ metadata:
     {{- with .Values.metrics.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
   {{- with .Values.metrics.annotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -19,9 +19,10 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   selector:
-    {{- include "kubelet-csr-approver.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "kubelet-csr-approver.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: {{ .Values.metrics.port }}
+    - port: metrics
       path: /metrics
       scheme: http
       {{- with .Values.metrics.serviceMonitor.interval }}


### PR DESCRIPTION
fix #172 

- [x] endpoint port should be [the name of the service port](https://github.com/prometheus-operator/prometheus-operator/blob/ec8188c48b186becae6041bcd439fa640086a1e4/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml#L356)
- [x] label selector missing [matchLabels](https://github.com/prometheus-operator/prometheus-operator/blob/ec8188c48b186becae6041bcd439fa640086a1e4/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml#L684) level