### PR TITLE
feat: allow adding extra objects to helm chart

### DIFF
--- a/charts/kubelet-csr-approver/templates/_helpers.tpl
+++ b/charts/kubelet-csr-approver/templates/_helpers.tpl
@@ -69,3 +69,12 @@ Create the name of the service account to use
   {{- .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Render yaml from values */}}
+{{- define "tplvalues.render" -}}
+  {{- if typeIs "string" .value }}
+      {{- tpl .value .context }}
+  {{- else }}
+      {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end }}

--- a/charts/kubelet-csr-approver/templates/_helpers.tpl
+++ b/charts/kubelet-csr-approver/templates/_helpers.tpl
@@ -72,9 +72,10 @@ Create the name of the service account to use
 
 {{/* Render yaml from values */}}
 {{- define "tplvalues.render" -}}
-  {{- if typeIs "string" .value }}
-      {{- tpl .value .context }}
-  {{- else }}
-      {{- tpl (.value | toYaml) .context }}
-  {{- end }}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+    {{- tpl $value .context }}
+{{- else }}
+    {{- $value }}
 {{- end }}
+{{- end -}}

--- a/charts/kubelet-csr-approver/templates/extra-list.yaml
+++ b/charts/kubelet-csr-approver/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "tplvalues.render" (dict "value"  "context" $) }}
+{{- end }}

--- a/charts/kubelet-csr-approver/templates/extra-list.yaml
+++ b/charts/kubelet-csr-approver/templates/extra-list.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraDeploy }}
 ---
-{{ include "tplvalues.render" (dict "value"  "context" $) }}
+{{ include "tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/kubelet-csr-approver/templates/extra-objects.yaml
+++ b/charts/kubelet-csr-approver/templates/extra-objects.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.extraDeploy }}
+{{- range .Values.extraObjects }}
 ---
 {{ include "tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -101,3 +101,5 @@ env: []
 
 dnsPolicy: ""
 dnsConfig: {}
+
+extraDeploy: []

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -103,7 +103,7 @@ dnsPolicy: ""
 dnsConfig: {}
 
 # Include additional objects within the chart
-extraDeploy: []
+extraObjects: []
 # - |
 #   apiVersion: v1
 #   kind: Secret

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -59,8 +59,7 @@ podAnnotations: {}
 
 podLabels: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 65532
 
 securityContext:

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -59,7 +59,8 @@ podAnnotations: {}
 
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 65532
 
 securityContext:
@@ -102,4 +103,12 @@ env: []
 dnsPolicy: ""
 dnsConfig: {}
 
+# Include additional objects within the chart
 extraDeploy: []
+# - |
+#   apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: my-special-secret
+#   data:
+#     key: value


### PR DESCRIPTION
Great project, thanks for your efforts!

This PR aims to add the ability to allow addition of extra objects that can be deployed alongside the helm chart.

Use Case:
Our kubernetes cluster allows only internal image registries. With this addition, we will be able to create the secret object which provides the imagePullSecret alongside the helm chart deployment.