### PR TITLE
[Helm Chart] Remove ServiceMonitor's namespaceSelector

### DIFF
--- a/charts/kubelet-csr-approver/templates/servicemonitor.yaml
+++ b/charts/kubelet-csr-approver/templates/servicemonitor.yaml
@@ -15,9 +15,6 @@ metadata:
   {{- end }}
 spec:
   jobLabel: {{ .Release.Name }}
-  namespaceSelector:
-    matchNames:
-      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "kubelet-csr-approver.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
`Release.Namespace` is specified in `ServiceMonitor`'s `namespaceSelector`, but the namespace actually installed is the `kubelet-csr-approver.namespace`.

Therefore, the `ServiceMonitor` will not work properly if it is installed in a namespace other than the default namespace.

There is no need to specify a `namespaceSelector` because the `namespaceSelector` defaults to the namespace to which the `ServiceMonitor` belongs, which is also the namespace to which the `Service` belongs.