### PR TITLE
feat: Allow specifying (optional) priorityClass

### DIFF
--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -59,6 +59,9 @@ podAnnotations: {}
 
 podLabels: {}
 
+# PriorityClass indicates the importance of a Pod relative to other Pods.
+priorityClassName: ""
+
 podSecurityContext: {}
   # fsGroup: 65532
 


### PR DESCRIPTION
Add optional value to specificy the priorityclass to use for the pods.
See https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/