### PR TITLE
feat: add flag to disable CSR denial  

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ it permits having a DNS name that differs (i.e. isn't prefixed) by the hostname
   with a _Username_ different than `system:node:......`. \
   the default value of the boolean is false, and if you want to use this feature
   you need to set this flag to `true`
+* `--skip-deny-step` or `SKIP_DENY_STEP` permits skipping denial of CSRs. when
+  set to true, kubelet-csr-approver will only ever approve a CSR, never deny
+  it.
 * `--allowed-dns-names` or `ALLOWED_DNS_NAMES` permits allowing more than one
   DNS name in the certificate request. the default value is set to 1.
 * `--leader-election` or `LEADER_ELECTION` permits enabling leader election

--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
             - name: IGNORE_NON_SYSTEM_NODE
               value: {{ .Values.ignoreNonSystemNode | quote }}
           {{- end }}
+          {{- if .Values.skipDenyStep }}
+            - name: SKIP_DENY_STEP
+              value: {{ .Values.skipDenyStep | quote }}
+          {{- end }}
           {{- if .Values.allowedDnsNames}}
             - name: ALLOWED_DNS_NAMES
               value: {{ .Values.allowedDnsNames | quote }}

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -8,6 +8,8 @@ bypassDnsResolution: false
 allowedDnsNames: 1
 # optional, permits ignoring CSRs with another Username than `system:node:...`
 ignoreNonSystemNode: false
+# optional, prevents csr denial, i.e. only lets kubelet-csr-approver approve valid CSRs but ignore other CSRs
+skipDenyStep: false
 # set this parameter to true to ignore mismatching DNS name and hostname
 bypassHostnameCheck: false
 # optional, list of IP (IPv4, IPv6) subnets that are allowed to submit CSRs

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -159,6 +159,7 @@ func prepareCmdlineConfig() *controller.Config {
 		bypassDNSResolution    = fs.Bool("bypass-dns-resolution", false, "set this parameter to true to bypass DNS resolution checks")
 		bypassHostnameCheck    = fs.Bool("bypass-hostname-check", false, "set this parameter to true to ignore mismatching DNS name and hostname")
 		ignoreNonSystemNodeCsr = fs.Bool("ignore-non-system-node", false, "set this parameter to true to ignore CSR for subjects different than system:node")
+		skipDenyCSR            = fs.Bool("skip-deny-step", false, "set this parameter to skip denying non-compliant csr")
 		allowedDNSNames        = fs.Int("allowed-dns-names", 1, "number of DNS SAN names allowed in a certificate request. defaults to 1")
 		ipPrefixesStr          = fs.String("provider-ip-prefixes", "0.0.0.0/0,::/0",
 			`provider-specified, comma separated ip prefixes that CSR IP addresses shall fall into.
@@ -185,7 +186,7 @@ func prepareCmdlineConfig() *controller.Config {
 	}
 
 	config := controller.Config{
-		LogLevel:               *logLevel,
+		LogLevel:               int8(*logLevel),
 		MetricsAddr:            *metricsAddr,
 		ProbeAddr:              *probeAddr,
 		LeaderElection:         *leaderElection,
@@ -194,6 +195,7 @@ func prepareCmdlineConfig() *controller.Config {
 		BypassDNSResolution:    *bypassDNSResolution,
 		BypassHostnameCheck:    *bypassHostnameCheck,
 		IgnoreNonSystemNodeCsr: *ignoreNonSystemNodeCsr,
+		SkipDenyCSR:            *skipDenyCSR,
 		MaxExpirationSeconds:   int32(*maxSec),
 		AllowedDNSNames:        *allowedDNSNames,
 	}


### PR DESCRIPTION
in that mode, CSR which are not automatically approved are simply left untouched.

is used with the `skip-deny-step` flag