### PR TITLE
fix: typo in env var name in helm chart (MAX_EXPIRATION_SEC)

### DIFF
--- a/charts/kubelet-csr-approver/templates/deployment.yaml
+++ b/charts/kubelet-csr-approver/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
               value: "{{ join "," .Values.providerIpPrefixes }}"
           {{- end }}
           {{- if .Values.maxExpirationSeconds}}
-            - name: MAX_EXPIRATION_SECONDS
+            - name: MAX_EXPIRATION_SEC
               value: {{ .Values.maxExpirationSeconds | quote }}
           {{- end }}
           {{- if .Values.bypassDnsResolution}}

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               value: ^[abcdef]\.test\.ch$
             - name: PROVIDER_IP_PREFIXES
               value: "0.0.0.0/0,::/0"
-            - name: MAX_EXPIRATION_SECONDS
+            - name: MAX_EXPIRATION_SEC
               value: "31622400" # 366 days
 
       tolerations:


### PR DESCRIPTION
The Helm chart sets `MAX_EXPIRATION_SECONDS` but according to the README and the [code](https://github.com/postfinance/kubelet-csr-approver/blob/2bcaf1eeb6f04801c88a2ff968195d87f31fe3e0/internal/cmd/cmd.go#L158) it should be `MAX_EXPIRATION_SEC`