### PR TITLE
fix(chart): remove namespace from ClusterRoleBinding metadata

### DIFF
--- a/charts/kubelet-csr-approver/templates/rolebinding.yaml
+++ b/charts/kubelet-csr-approver/templates/rolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "kubelet-csr-approver.fullname" . }}
-  namespace: {{ include "kubelet-csr-approver.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Hi,
This PR for minor fix in the Helm chart, remove the `metadata.namespace` field from the `ClusterRoleBinding`  template.

As we know, `ClusterRoleBinding` is a cluster scoped Kubernetes resource and does not belong to any namespace. 
Therefore, the Helm chart should not render a namespace under its metadata.

Thanks.