### PR TITLE
feat(chart): add NodePort service support

### DIFF
--- a/charts/kubelet-csr-approver/templates/service.yaml
+++ b/charts/kubelet-csr-approver/templates/service.yaml
@@ -14,20 +14,14 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.metrics.serviceType | default "ClusterIP" }}
-  {{- if and (eq .Values.metrics.serviceType "NodePort") .Values.metrics.nodePort }}
   ports:
     - port: {{ .Values.metrics.port }}
       targetPort: metrics
       protocol: TCP
       name: metrics
-      nodePort: {{ .Values.metrics.nodePort }}
-  {{- else }}
-  ports:
-    - port: {{ .Values.metrics.port }}
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
-  {{- end }}
+      {{- with .Values.metrics.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "kubelet-csr-approver.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/kubelet-csr-approver/templates/service.yaml
+++ b/charts/kubelet-csr-approver/templates/service.yaml
@@ -13,12 +13,21 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.metrics.serviceType }}
+  type: {{ .Values.metrics.serviceType | default "ClusterIP" }}
+  {{- if and (eq .Values.metrics.serviceType "NodePort") .Values.metrics.nodePort }}
   ports:
     - port: {{ .Values.metrics.port }}
       targetPort: metrics
       protocol: TCP
       name: metrics
+      nodePort: {{ .Values.metrics.nodePort }}
+  {{- else }}
+  ports:
+    - port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- end }}
   selector:
     {{- include "kubelet-csr-approver.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/kubelet-csr-approver/values.yaml
+++ b/charts/kubelet-csr-approver/values.yaml
@@ -42,6 +42,7 @@ metrics:
   enable: true
   serviceType: ClusterIP
   port: 8080
+  nodePort: ""
   annotations: {}
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
Hi,

I would like to request feature `NodePort` in the chart,
This PR for adding support for exposing the service through `NodePort` in addition to the existing service types:
https://github.com/postfinance/kubelet-csr-approver/blob/993754fb9c443bf7f51a2d035e43a08b394ca3d3/charts/kubelet-csr-approver/values.yaml#L41-L43
It supports changing the type but not the configs in the `service.yaml` template (this forces to use ClusterIP).

For example case, I have a separate monitoring cluster that scrapes services running in other Kubernetes clusters, and exposing the metrics service via `NodePort`.

Thank you in advance!